### PR TITLE
Add build script and instructions for running the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Demo of Prius in ROS/GAZEBO
+
+This is a simulation of a Prius in [gazebo 8](http://gazebosim.org) with sensor data being published using [ROS kinetic](http://wiki.ros.org/kinetic/Installation)
+The car's throttle, brake, steering, and gear shifting are controlled by publishing a ROS message.
+A ROS node allows driving with a gamepad or joystick.
+
+
+# Requirements
+
+This demo has been tested on Ubuntu Xenial (16.04)
+
+* An X server
+* [Docker](https://www.docker.com/get-docker)
+* [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/wiki/Installation)
+
+# Recommended
+
+* A joystick
+* A joystick driver which creates links to `/dev/input/js0` or `/dev/input/js1`
+
+# Building
+
+First clone the repo, then run the script `build_demo.bash`.
+It builds a docker image with the local source code inside.
+
+```
+$ cd car_demo
+$ ./build_demo.bash
+```
+
+# Running
+
+Connect a game controller to your PC.
+Use the script `run_demo.bash` to run the demo.
+
+```
+$ ./run_demo.bash
+```
+An [RVIZ](http://wiki.ros.org/rviz) window will open showing the car and sensor output.
+A gazebo window will appear showing the simulation.
+Either use the controller to drive the prius around the world, or click on the gazebo window and use the `WASD` keys to drive the car.
+
+If using a Logitech F710 controller:
+
+* Make sure the MODE status light is off
+* Set the swtich to XInput mode
+* The right stick controls throttle and brake
+* The left stick controls steering
+* Y puts the car into DRIVE
+* A puts the car into REVERSE
+* B puts the car into NEUTRAL

--- a/build_demo.bash
+++ b/build_demo.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+sudo docker build -t osrf/car_demo $DIR

--- a/run_demo.bash
+++ b/run_demo.bash
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Runs a docker container with the image created by build_demo.bash
+# Requires
+#   docker
+#   nvidia-docker 
+#   an X server
+# Recommended
+#   A joystick mounted to /dev/input/js0 or /dev/input/js1
 
 until sudo nvidia-docker ps
 do
@@ -23,7 +30,6 @@ then
     chmod a+r $XAUTH
 fi
 
-# Display is hard-coded to :0 because that's what the startup scripts on AWS will generate
 sudo nvidia-docker run -it \
   -e DISPLAY \
   -e QT_X11_NO_MITSHM=1 \
@@ -31,8 +37,7 @@ sudo nvidia-docker run -it \
   -v "$XAUTH:$XAUTH" \
   -v "/tmp/.X11-unix:/tmp/.X11-unix" \
   -v "/etc/localtime:/etc/localtime:ro" \
-  -v "/var/run/spnav.sock:/var/run/spnav.sock" \
   -v "/dev/input:/dev/input" \
   --privileged \
   --rm=true \
-  car_demo
+  osrf/car_demo


### PR DESCRIPTION
This adds a README with instructions on building and running the demo. Additionally it adds a build script and renames the docker image to osrf/gazebo in anticipation of pushing the image to dockerhub.