### PR TITLE
APACHE 2.0 license for car_demo

### DIFF
--- a/car_demo/nodes/joystick_translator
+++ b/car_demo/nodes/joystick_translator
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright 2017 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import rospy
 from prius_msgs.msg import Control

--- a/car_demo/package.xml
+++ b/car_demo/package.xml
@@ -5,7 +5,7 @@
   The car demo
   </description>
   <maintainer email="tfoote@openrobotics.org">Tully Foote</maintainer>
-  <license>BSD</license>
+  <license>APACHE 2.0</license>
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>gazebo_ros</depend>


### PR DESCRIPTION
This changes the `<license>` tag in `car_demo` to the Apache 2.0 license, and adds a license notice to `joystick_translator`.