### PR TITLE
fix bug where oversteer by factor of 2

### DIFF
--- a/car_demo/plugins/PriusHybridPlugin.cc
+++ b/car_demo/plugins/PriusHybridPlugin.cc
@@ -320,7 +320,11 @@ void PriusHybridPlugin::OnPriusCommand(const prius_msgs::Control::ConstPtr &msg)
   double handWheelRange =
     this->dataPtr->handWheelHigh - this->dataPtr->handWheelLow;
 
-  double handCmd = msg->steer * handWheelRange;
+  //double handCmd = msg->steer * handWheelRange;
+  double handCmd = (msg->steer < 0.)
+    ? (msg->steer * -this->dataPtr->handWheelLow)
+    : (msg->steer * this->dataPtr->handWheelHigh);
+    
   handCmd = ignition::math::clamp(handCmd, this->dataPtr->handWheelLow,
       this->dataPtr->handWheelHigh);
   this->dataPtr->handWheelCmd = handCmd;

--- a/car_demo/plugins/PriusHybridPlugin.cc
+++ b/car_demo/plugins/PriusHybridPlugin.cc
@@ -317,10 +317,6 @@ void PriusHybridPlugin::OnPriusCommand(const prius_msgs::Control::ConstPtr &msg)
   this->dataPtr->lastPedalCmdTime = this->dataPtr->world->SimTime();
 
   // Steering wheel command
-  double handWheelRange =
-    this->dataPtr->handWheelHigh - this->dataPtr->handWheelLow;
-
-  //double handCmd = msg->steer * handWheelRange;
   double handCmd = (msg->steer < 0.)
     ? (msg->steer * -this->dataPtr->handWheelLow)
     : (msg->steer * this->dataPtr->handWheelHigh);

--- a/car_demo/plugins/PriusHybridPlugin.cc
+++ b/car_demo/plugins/PriusHybridPlugin.cc
@@ -320,7 +320,7 @@ void PriusHybridPlugin::OnPriusCommand(const prius_msgs::Control::ConstPtr &msg)
   double handCmd = (msg->steer < 0.)
     ? (msg->steer * -this->dataPtr->handWheelLow)
     : (msg->steer * this->dataPtr->handWheelHigh);
-    
+
   handCmd = ignition::math::clamp(handCmd, this->dataPtr->handWheelLow,
       this->dataPtr->handWheelHigh);
   this->dataPtr->handWheelCmd = handCmd;


### PR DESCRIPTION
Assuming handWheelHigh = -handWheelLow = X, then handWheelRange is 2X.  msg->steer is in [-1,+1] so handCmd would be in [-2X, 2X].  This is then clamped.  The result is a factor of two scale on the steering angle. 