### PR TITLE
Changes for nvidia-docker v2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM osrf/ros:kinetic-desktop
-
-LABEL com.nvidia.volumes.needed="nvidia_driver"
-ENV PATH /usr/local/nvidia/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+FROM osrf/ros:kinetic-desktop-opengl
 
 RUN apt-get update \
  && apt-get install -y \

--- a/ros_opengl/Dockerfile
+++ b/ros_opengl/Dockerfile
@@ -1,0 +1,43 @@
+# This is an auto generated Dockerfile for ros:ros-core
+# generated from docker_images/create_ros_core_image.Dockerfile.em
+# FROM ubuntu:xenial
+FROM nvidia/opengl:runtime
+
+# install packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO kinetic
+RUN apt-get update && apt-get install -y \
+    ros-kinetic-desktop-full \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros_opengl/build_base.bash
+++ b/ros_opengl/build_base.bash
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-./ros_opengl/build_base.bash
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-sudo docker build -t osrf/car_demo $DIR
+sudo docker build -t osrf/ros:kinetic-desktop-opengl $DIR

--- a/ros_opengl/ros_entrypoint.sh
+++ b/ros_opengl/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"


### PR DESCRIPTION
### WIP

As nvidia-docker v1 is now deprecated with the release of [nvidia-docker v2](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0)#removing-nvidia-docker-10), I just wanted to investigate how nvidia-docker2 may be used to the same effect to provide harware accelerated graphics within containers. The depreciation of nvidia-docker v1 thus requires some changes, as the use of nvidia-docker v2 is [not directly reverse compatible](https://github.com/osrf/docker_images/issues/105#issuecomment-355136703). As noted by the maintainer [here](https://github.com/NVIDIA/nvidia-docker/issues/11#issuecomment-356802940), OpenGL images supporting nvidia-docker2's runtime have been released by nvidia.

This PR is a simple working example in modify legacy use application to achieve the same capability of contained display pass through over X server, by swapping out base image with opengl runtime image from nvidia.

TODO: narrow down minimum set changes needed without radical base image swap. I'm not sure how much of nvidia's libglvnd we need for OpenGL API call dispatch, but perhaps there might be an more simplified workaround.