### PR TITLE
Depend on prius_msgs

### DIFF
--- a/car_demo/CMakeLists.txt
+++ b/car_demo/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(ignition-msgs0 REQUIRED)
 catkin_package(
  # INCLUDE_DIRS include
  # LIBRARIES gazebo_radar_plugin
- CATKIN_DEPENDS gazebo_ros
+ CATKIN_DEPENDS gazebo_ros prius_msgs
 #  DEPENDS system_lib
 )
 
@@ -25,9 +25,11 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFo
 
 add_library(PriusHybridPlugin SHARED plugins/PriusHybridPlugin.cc)
 target_link_libraries(PriusHybridPlugin ${GAZEBO_LIBRARIES} ${IGNITION-MSGS_LIBRARIES})
+add_dependencies(PriusHybridPlugin ${catkin_EXPORTED_TARGETS})
 
 add_library(gazebo_ros_block_laser SHARED plugins/gazebo_ros_block_laser.cpp)
 target_link_libraries(gazebo_ros_block_laser ${GAZEBO_LIBRARIES} ${IGNITION-MSGS_LIBRARIES})
+add_dependencies(gazebo_ros_block_laser ${catkin_EXPORTED_TARGETS})
 
 catkin_install_python(PROGRAMS nodes/joystick_translator
                       DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
This ensures that `prius_msgs` is available before building the plugins.