### PR TITLE
[WIP] Updating for nvidia-docker2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros:kinetic-desktop
+FROM osrf/ros:melodic-desktop
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
@@ -13,21 +13,21 @@ RUN mkdir -p $CATKIN_WS/src
 WORKDIR $CATKIN_WS/src
 
 # copy source code
-COPY prius_description .
-COPY prius_msgs .
-COPY car_demo .
+COPY prius_description ./prius_description
+COPY prius_msgs ./prius_msgs
+COPY car_demo ./car_demo
+RUN git clone https://github.com/ros-planning/navigation.git
+RUN git clone https://github.com/ros-drivers/joystick_drivers.git
 
 # install package dependacies
 RUN apt-get -qq update && \
     apt-get -qq install -y \
-        python-catkin-tools && \
+      python-catkin-tools && \
     rosdep update && \
     rosdep install -y \
       --from-paths . \
       --ignore-src \
       --rosdistro ${ROS_DISTRO} \
-      --skip-keys=prius_msgs \
-      --skip-keys=prius_description \
       --as-root=apt:false && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,56 @@
 FROM osrf/ros:kinetic-desktop
 
-LABEL com.nvidia.volumes.needed="nvidia_driver"
-ENV PATH /usr/local/nvidia/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
-RUN apt-get update \
- && apt-get install -y \
-    wget \
-    lsb-release \
-    sudo \
-    mesa-utils \
- && apt-get clean
+# setup sources.list
+RUN . /etc/os-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
+# setup catkin workspace
+ENV CATKIN_WS=/root/catkin_ws
+RUN mkdir -p $CATKIN_WS/src
+WORKDIR $CATKIN_WS/src
 
-# Get gazebo binaries
-RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list \
- && wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \
- && apt-get update \
- && apt-get install -y \
-    gazebo8 \
-    ros-kinetic-gazebo8-ros-pkgs \
-    ros-kinetic-fake-localization \
-    ros-kinetic-joy \
- && apt-get clean
+# copy source code
+COPY prius_description .
+COPY prius_msgs .
+COPY car_demo .
 
+# install package dependacies
+RUN apt-get -qq update && \
+    apt-get -qq install -y \
+        python-catkin-tools && \
+    rosdep update && \
+    rosdep install -y \
+      --from-paths . \
+      --ignore-src \
+      --rosdistro ${ROS_DISTRO} \
+      --skip-keys=prius_msgs \
+      --skip-keys=prius_description \
+      --as-root=apt:false && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /tmp/workspace/src
-COPY prius_description /tmp/workspace/src/prius_description
-COPY prius_msgs /tmp/workspace/src/prius_msgs
-COPY car_demo /tmp/workspace/src/car_demo
-RUN /bin/bash -c 'cd /tmp/workspace \
- && source /opt/ros/kinetic/setup.bash \
- && catkin_make'
+# build from source
+WORKDIR $CATKIN_WS
+ENV TERM xterm
+ENV PYTHONIOENCODING UTF-8
+RUN catkin config \
+      --extend /opt/ros/$ROS_DISTRO && \
+    catkin build
 
+# install display dependencies
+RUN apt-get update && apt-get install -y \
+      libglvnd0 \
+      mesa-utils \
+    && rm -rf /var/lib/apt/lists/*
 
-CMD ["/bin/bash", "-c", "source /opt/ros/kinetic/setup.bash && source /tmp/workspace/devel/setup.bash && roslaunch car_demo demo.launch"]
+ # nvidia-container-runtime (nvidia-docker2)
+ ENV NVIDIA_VISIBLE_DEVICES \
+     ${NVIDIA_VISIBLE_DEVICES:-all}
+ ENV NVIDIA_DRIVER_CAPABILITIES \
+     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+ENTRYPOINT ["/ros_entrypoint.sh"]

--- a/car_demo/CMakeLists.txt
+++ b/car_demo/CMakeLists.txt
@@ -11,8 +11,8 @@ find_package(catkin REQUIRED COMPONENTS
   prius_msgs
 )
 
-find_package(gazebo 8 REQUIRED)
-find_package(ignition-msgs0 REQUIRED)
+find_package(gazebo REQUIRED)
+find_package(ignition-msgs1 REQUIRED)
 
 catkin_package(
  # INCLUDE_DIRS include

--- a/ros_entrypoint.sh
+++ b/ros_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+source "$CATKIN_WS/devel/setup.bash"
+exec "$@"

--- a/run_demo.bash
+++ b/run_demo.bash
@@ -3,16 +3,10 @@
 # Runs a docker container with the image created by build_demo.bash
 # Requires
 #   docker
-#   nvidia-docker 
+#   nvidia-docker2
 #   an X server
 # Recommended
 #   A joystick mounted to /dev/input/js0 or /dev/input/js1
-
-until sudo nvidia-docker ps
-do
-    echo "Waiting for docker server"
-    sleep 1
-done
 
 
 # Make sure processes in the container can connect to the x server
@@ -30,14 +24,15 @@ then
     chmod a+r $XAUTH
 fi
 
-sudo nvidia-docker run -it \
-  -e DISPLAY \
-  -e QT_X11_NO_MITSHM=1 \
-  -e XAUTHORITY=$XAUTH \
-  -v "$XAUTH:$XAUTH" \
-  -v "/tmp/.X11-unix:/tmp/.X11-unix" \
-  -v "/etc/localtime:/etc/localtime:ro" \
-  -v "/dev/input:/dev/input" \
+docker run -it --rm \
+  --runtime=nvidia \
+  --env DISPLAY \
+  --env QT_X11_NO_MITSHM=1 \
+  --env XAUTHORITY=$XAUTH \
+  --volume "$XAUTH:$XAUTH" \
+  --volume "/tmp/.X11-unix:/tmp/.X11-unix" \
+  --volume "/etc/localtime:/etc/localtime:ro" \
+  --volume "/dev/input:/dev/input" \
   --privileged \
-  --rm=true \
-  osrf/car_demo
+  osrf/car_demo \
+  roslaunch car_demo demo.launch


### PR DESCRIPTION
This won't build yet for two reasons:
* `libglvnd0` is not yet released into trusy
* catkin build errors about not find a package configuration file for prius_msgs

I'd like to bump this up to melodic to get `libglvnd0`, but `fake-localization` has not yet been released.

Here is the build issue, I'm not sure why `catkin_make` works here by `catkin_tools` doesn't.

<details/>
  <summary>Build errors</summary>

``` bash
$ ./build_demo.bash 
Sending build context to Docker daemon  107.6MB
Step 1/19 : FROM osrf/ros:kinetic-desktop
 ---> 2046fd743c87
Step 2/19 : RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 ---> Using cache
 ---> e1767ad9da53
Step 3/19 : RUN . /etc/os-release     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 ---> Using cache
 ---> 89207373b5f8
Step 4/19 : ENV CATKIN_WS=/root/catkin_ws
 ---> Using cache
 ---> c379ef55af9d
Step 5/19 : RUN mkdir -p $CATKIN_WS/src
 ---> Using cache
 ---> 1b4919ffc79b
Step 6/19 : WORKDIR $CATKIN_WS/src
 ---> Using cache
 ---> c51536569585
Step 7/19 : COPY prius_description .
 ---> Using cache
 ---> 8c734db0f937
Step 8/19 : COPY prius_msgs .
 ---> Using cache
 ---> 9aa9f9366496
Step 9/19 : COPY car_demo .
 ---> Using cache
 ---> 63a1b59b6fed
Step 10/19 : RUN apt-get -qq update &&     apt-get -qq install -y         python-catkin-tools &&     rosdep update &&     rosdep install -y       --from-paths .       --ignore-src       --rosdistro ${ROS_DISTRO}       --skip-keys=prius_msgs       --skip-keys=prius_description       --as-root=apt:false &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> c5a66f73f5e9
Step 11/19 : WORKDIR $CATKIN_WS
 ---> Using cache
 ---> e71eda23557c
Step 12/19 : ENV TERM xterm
 ---> Using cache
 ---> cb2c0f1ab8c0
Step 13/19 : ENV PYTHONIOENCODING UTF-8
 ---> Using cache
 ---> e0eb63dc3386
Step 14/19 : RUN catkin config       --extend /opt/ros/$ROS_DISTRO &&     catkin build
 ---> Running in 877d1f619a4c
NOTICE: Could not determine the width of the terminal. A default width of 80 will be used. This warning will only be printed once.
----------------------------------------------------
Profile:                     default
Extending:        [explicit] /opt/ros/kinetic
Workspace:                   /root/catkin_ws
----------------------------------------------------
Source Space:       [exists] /root/catkin_ws/src
Log Space:         [missing] /root/catkin_ws/logs
Build Space:       [missing] /root/catkin_ws/build
Devel Space:       [missing] /root/catkin_ws/devel
Install Space:      [unused] /root/catkin_ws/install
DESTDIR:            [unused] None
----------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
----------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
----------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
----------------------------------------------------
Workspace configuration appears valid.

Initialized new catkin workspace in `/root/catkin_ws`
----------------------------------------------------
NOTICE: Could not determine the width of the terminal. A default width of 80 will be used. This warning will only be printed once.
----------------------------------------------------
Profile:                     default
Extending:        [explicit] /opt/ros/kinetic
Workspace:                   /root/catkin_ws
----------------------------------------------------
Source Space:       [exists] /root/catkin_ws/src
Log Space:         [missing] /root/catkin_ws/logs
Build Space:        [exists] /root/catkin_ws/build
Devel Space:        [exists] /root/catkin_ws/devel
Install Space:      [unused] /root/catkin_ws/install
DESTDIR:            [unused] None
----------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
----------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
----------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
----------------------------------------------------
Workspace configuration appears valid.

NOTE: Forcing CMake to run for each package.
----------------------------------------------------
[build] Found '1' packages in 0.0 seconds.                                     
[build] Updating package table.                                                
Starting >>> catkin_tools_prebuild                                             
Finished <<< catkin_tools_prebuild                [ 2.4 seconds ]              
Starting >>> car_demo                                                          
_______________________________________________________________________________
Errors << car_demo:cmake /root/catkin_ws/logs/car_demo/build.cmake.000.log     
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by "prius_msgs" with
  any of the following names:

    prius_msgsConfig.cmake
    prius_msgs-config.cmake

  Add the installation prefix of "prius_msgs" to CMAKE_PREFIX_PATH or set
  "prius_msgs_DIR" to a directory containing one of the above files.  If
  "prius_msgs" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:9 (find_package)


CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by "prius_msgs" with
  any of the following names:

    prius_msgsConfig.cmake
    prius_msgs-config.cmake

  Add the installation prefix of "prius_msgs" to CMAKE_PREFIX_PATH or set
  "prius_msgs_DIR" to a directory containing one of the above files.  If
  "prius_msgs" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:9 (find_package)


cd /root/catkin_ws/build/car_demo; catkin build --get-env car_demo | catkin env -si  /usr/bin/cmake /root/catkin_ws/src/. --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/root/catkin_ws/devel/.private/car_demo -DCMAKE_INSTALL_PREFIX=/root/catkin_ws/install; cd -
...............................................................................
Failed << car_demo:cmake                        [ Exited with code 1 ]         
Failed <<< car_demo                             [ 2.5 seconds ]                
[build] Summary: 1 of 2 packages succeeded.                                    
[build] Ignored: None.                                                         
[build] Warnings: None.                                                        
[build] Abandoned: No packages were abandoned.                                 
[build] Failed: 1 packages failed.                                             
[build] Runtime: 4.9 seconds total.                                            
[build] Note: Workspace packages have changed, please re-source setup files to use them.
The command '/bin/sh -c catkin config       --extend /opt/ros/$ROS_DISTRO &&     catkin build' returned a non-zero code: 1

```

</details>

ping @tfoote if you see a glaring error I made.