### PR TITLE
Add the channel name for intensity in gazebo_ros_block_laser.cpp

### DIFF
--- a/car_demo/plugins/gazebo_ros_block_laser.cpp
+++ b/car_demo/plugins/gazebo_ros_block_laser.cpp
@@ -265,6 +265,9 @@ void GazeboRosBlockLaser::PutLaserData(common::Time &_updateTime)
   this->cloud_msg_.channels.clear();
   this->cloud_msg_.channels.push_back(sensor_msgs::ChannelFloat32());
 
+		// name the channel[0] for "intensity"
+  this->cloud_msg_.channels[0].name = "intensity";
+
   /***************************************************************/
   /*                                                             */
   /*  point scan from laser                                      */


### PR DESCRIPTION
The PointCloud format needs a name for each channel.
The gazebo_ros_block_laser.cpp only pushback the intensity value, that
lead to rviz and another package cannot recognize the intensity channel.