### PR TITLE
X11 rendering fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN /bin/bash -c 'cd /tmp/workspace \
  && catkin_make'
 
 
-CMD ["/bin/bash", "-c", "source /opt/ros/kinetic/setup.bash && source /tmp/workspace/devel/setup.bash && roslaunch car_demo demo.launch"]
+CMD ["/bin/bash", "-c", "source /opt/ros/kinetic/setup.bash && source /tmp/workspace/devel/setup.bash && sudo chmod 777 /home/ && roslaunch car_demo demo.launch"]

--- a/run_demo.bash
+++ b/run_demo.bash
@@ -20,4 +20,4 @@ python3 -m venv /tmp/car_demo_rocker_venv
 pip install -U git+https://github.com/osrf/rocker.git
 
 
-rocker --nvidia --user --devices /dev/input/js0 /dev/input/js1 -- osrf/car_demo
+rocker --nvidia --x11 --user --devices /dev/input/js0 /dev/input/js1 -- osrf/car_demo


### PR DESCRIPTION
Fixing X11 rendering issue on Ubuntu 16.04 by enabling X11 port forwarding in rocker & enabling user to run the demo image without sudo permission by making /home/ of docker image writable by guest user.
Nvidia driver version tested - 396.54
CUDA version - 9.2

This pull-request fixes the errors in **bold** - 

[ INFO] [1553300931.707573484]: Finished loading Gazebo ROS API Plugin.
[Msg] Waiting for master.
[ INFO] [1553300931.707965557]: waitForService: Service [/gazebo/set_physics_properties] has not been advertised, waiting...
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 172.17.0.2
**[Err] [RenderEngine.cc:725] Can't open display:** 
[Wrn] [RenderEngine.cc:93] Unable to create X window. Rendering will be disabled
[Wrn] [RenderEngine.cc:293] Cannot initialize render engine since render path type is NONE. Ignore this warning ifrendering has been turned off on purpose.
process[gazebo_gui-3]: started with pid [128]
Gazebo multi-robot simulator, version 9.7.0
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[Wrn] [GuiIface.cc:202] g/gui-plugin is really loading a SystemPlugin. To load a GUI plugin please use --gui-client-plugin 
process[robot_state_publisher-4]: started with pid [201]
[ INFO] [1553300931.931827192]: Finished loading Gazebo ROS API Plugin.
[Msg] Waiting for master.
[ INFO] [1553300931.932416096]: waitForService: Service [/gazebo/set_physics_properties] has not been advertised, waiting...
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 172.17.0.2
[Wrn] [GuiIface.cc:300] Couldn't locate specified .ini. Creating file at "/home/luminosity/.gazebo/gui.ini"
**[Err] [RenderEngine.cc:725] Can't open display:** 
[Wrn] [RenderEngine.cc:93] Unable to create X window. Rendering will be disabled
[Wrn] [RenderEngine.cc:293] Cannot initialize render engine since render path type is NONE. Ignore this warning ifrendering has been turned off on purpose.
**[Err] [GuiIface.cc:126] QXcbConnection: Could not connect to display** 
Aborted (core dumped)
**No handlers could be found for logger "roslaunch"**
[gazebo_gui-3] process has died [pid 128, exit code 134, cmd /opt/ros/kinetic/lib/gazebo_ros/gzclient --verbose __name:=gazebo_gui __log:=/home/luminosity/.ros/log/a1665180-4d02-11e9-adf7-0242ac110002/gazebo_gui-3.log].
log file: /home/luminosity/.ros/log/a1665180-4d02-11e9-adf7-0242ac110002/gazebo_gui-3*.log
